### PR TITLE
Fix broken ec2_tag_filter block

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -176,9 +176,9 @@ resource "aws_codedeploy_deployment_group" "default" {
 
     content {
       ec2_tag_filter {
-        key   = ec2_tag_set.value.key
-        type  = ec2_tag_set.value.type
-        value = ec2_tag_set.value.value
+        key   = lookup(ec2_tag_set.value, "key", null)
+        type  = lookup(ec2_tag_set.value, "type", null)
+        value = lookup(ec2_tag_set.value, "value", null)
       }
     }
   }


### PR DESCRIPTION
## what
* This is to fix a bug when using the ec2-tag-filters

## why
* The dynamic block for_each and map lookups are broken

## references
* Closes https://github.com/cloudposse/terraform-aws-code-deploy/issues/6
