### PR TITLE
Fix ec2_tag_filter for_each

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -172,7 +172,7 @@ resource "aws_codedeploy_deployment_group" "default" {
   }
 
   dynamic "ec2_tag_set" {
-    for_each = var.ec2_tag_filter == null ? [] : [var.ec2_tag_filter]
+    for_each = var.ec2_tag_filter == null ? [] : var.ec2_tag_filter
 
     content {
       ec2_tag_filter {


### PR DESCRIPTION
## what
* Fix ec2_tag_filter for_each by using the input var without turning it into a list of a list

## why
* The input var is a list but the for_each tries to turn it into another list resulting in an error

## references
* Closes https://github.com/cloudposse/terraform-aws-code-deploy/issues/6

## test

```hcl
module "code_deploy" {
  source = "git::https://github.com/cloudposse/terraform-aws-code-deploy.git?ref=fix-ec2_tag_filter"

  # ...
}
```