### PR TITLE
docs: add code deploy project description

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,7 +17,6 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
-    - 'no-release'
   default: 'minor'
 
 categories:

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,9 +4,9 @@
     ":preserveSemverRanges"
   ],
   "labels": ["auto-update"],
+  "dependencyDashboardAutoclose": true,
   "enabledManagers": ["terraform"],
   "terraform": {
     "ignorePaths": ["**/context.tf", "examples/**"]
   }
 }
-

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Check out these related projects.
 - [terraform-aws-codebuild](https://github.com/cloudposse/terraform-aws-codebuild) - Terraform Module to easily leverage AWS CodeBuild for Continuous Integration
 - [terraform-aws-codepipeline-codedeploy](https://github.com/cloudposse/terraform-aws-codepipeline-codedeploy) - Terraform module that generates an AWS Codepipeline, and deploys via CodeDeploy
 - [terraform-aws-codefresh-backing-services](https://github.com/cloudposse/terraform-aws-codefresh-backing-services) - Terraform module to provision AWS backing services necessary to run Codefresh Enterprise
-- [terraform-aws-code-deploy](https://github.com/cloudposse/terraform-aws-code-deploy) - %!s(<nil>)
+- [terraform-aws-code-deploy](https://github.com/cloudposse/terraform-aws-code-deploy) - Terraform module to provision AWS Code Deploy app and group
 
 
 ## References
@@ -386,7 +386,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
-
+<!-- markdownlint-disable -->
   [logo]: https://cloudposse.com/logo-300x69.svg
   [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-code-deploy&utm_content=docs
   [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-code-deploy&utm_content=website
@@ -417,3 +417,4 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-aws-code-deploy
   [share_email]: mailto:?subject=terraform-aws-code-deploy&body=https://github.com/cloudposse/terraform-aws-code-deploy
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-aws-code-deploy?pixel&cs=github&cm=readme&an=terraform-aws-code-deploy
+<!-- markdownlint-restore -->

--- a/README.yaml
+++ b/README.yaml
@@ -54,7 +54,7 @@ related:
     Codefresh Enterprise
   url: https://github.com/cloudposse/terraform-aws-codefresh-backing-services
 - name: terraform-aws-code-deploy
-  description:
+  description: Terraform module to provision AWS Code Deploy app and group
   url: https://github.com/cloudposse/terraform-aws-code-deploy
 references:
 - name: terraform-provider-aws


### PR DESCRIPTION
## what
* fix the missing description for `terraform-aws-code-deploy` in related projects section of README

## why
* random text showing up in the README now
```
terraform-aws-code-deploy - %!s()
```

