### PR TITLE
Allow multiple target groups to be specified

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -232,6 +232,10 @@ resource "aws_codedeploy_deployment_group" "default" {
             [load_balancer_info.value.target_group_info]
           )
         )
+
+        content {
+          name = target_group_info.value.name
+        }
       }
 
       dynamic "target_group_pair_info" {

--- a/main.tf
+++ b/main.tf
@@ -226,11 +226,12 @@ resource "aws_codedeploy_deployment_group" "default" {
       }
 
       dynamic "target_group_info" {
-        for_each = lookup(load_balancer_info.value, "target_group_info", null) == null ? [] : [load_balancer_info.value.target_group_info]
-
-        content {
-          name = target_group_info.value.name
-        }
+        for_each = lookup(load_balancer_info.value, "target_group_info", null) == null ? [] : (
+          try(
+            tolist(load_balancer_info.value.target_group_info),
+            [load_balancer_info.value.target_group_info]
+          )
+        )
       }
 
       dynamic "target_group_pair_info" {


### PR DESCRIPTION
## what

Allow multiple target groups to be specified fro codedeploy maangement. This is required when there are multiple  target groups available for the given ASG.
